### PR TITLE
Make the component aware of the web manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Change the gui page title, favicon and app icons of your Home Assistant instance
 
 - Add a "Favicon" integration
 
-- Enter what you want the title of the Home Assistant interface page to be, and the URL of the icons you wish to change. E.g. `favicon URL: /local/favicons/favicon.ico`, `iOS icon URL: /local/favicons/180x180.png`.
+- Enter what you want the title of the Home Assistant interface page to be, and the URL of the icons you wish to change. For the App icons there must be at least one specified. E.g. `favicon URL: /local/favicons/favicon.ico`, `iOS icon URL: /local/favicons/180x180.png`, `App icon 1024px URL: /local/favicons/1024x1024.png`.
 
 - Press submit
 
@@ -33,13 +33,17 @@ Change the gui page title, favicon and app icons of your Home Assistant instance
 
 ## Method 2/2 YAML configuration
 
-- Add the following to your `configuration.yaml`:
+- Add the following to your `configuration.yaml` (For the icons-* there must be at least one of them specified):
 
 ```yaml
 favicon:
   title: My Home
   favicon: /local/favicons/favicon.ico
-  apple: /local/favicons/apple-touch-icon-180x180.png
+  icon-apple: /local/favicons/apple-touch-icon-180x180.png
+  icon-1024: /local/favicons/icon-1024x1024.png
+  icon-512: /local/favicons/icon-512x512.png
+  icon-384: /local/favicons/icon-384x384.png
+  icon-192: /local/favicons/icon-192x192.png
 ```
 
 - Restart Home Assistant
@@ -52,7 +56,9 @@ favicon:
 
 - `favicon` - an .ico file which is displayed in your browser tab or bookmark menu.
 
-- `apple` - a 180 x 180 px image that will be displayed on your iDevice home screen if you save the link there
+- `icon-apple` - a 180 x 180 px image that will be displayed on your iDevice home screen if you save the link there
+
+- `icon-*` - The app launcher icons for desktop and android phones. You need to specify at least one resolution (`1024, 512, 384, 192`) to make it work. Higher or lower resolutions will be created from the nearest size from your browser. The icons have to be png's.
 
 
 ![it IS charging thankyouverymuch](https://user-images.githubusercontent.com/1299821/62975899-c29d6480-be1b-11e9-9b6b-9d160ef8b439.jpg)

--- a/custom_components/favicon/.translations/en.json
+++ b/custom_components/favicon/.translations/en.json
@@ -8,7 +8,11 @@
         "data": {
           "title": "Page title",
           "favicon": "favicon URL",
-          "apple": "iOS icon URL"
+          "icon-apple": "iOS icon URL",
+          "icon-1024": "App icon 1024px URL",
+          "icon-512": "App icon 512px URL",
+          "icon-384": "App icon 384px URL",
+          "icon-192": "App icon 192px URL"
         }
       }
     },
@@ -22,7 +26,11 @@
         "data": {
           "title": "Page title",
           "favicon": "favicon URL",
-          "apple": "iOS icon URL"
+          "icon-apple": "iOS icon URL",
+          "icon-1024": "App icon 1024px URL",
+          "icon-512": "App icon 512px URL",
+          "icon-384": "App icon 384px URL",
+          "icon-192": "App icon 192px URL"
         }
       }
     }

--- a/custom_components/favicon/__init__.py
+++ b/custom_components/favicon/__init__.py
@@ -45,8 +45,8 @@ def apply_hooks(hass):
             text = render(*args, **kwargs)
             if data["favicon"]:
                 text = text.replace("/static/icons/favicon.ico", data["favicon"])
-            if data["apple"]:
-                text = text.replace("/static/icons/favicon-apple-180x180.png", data["apple"])
+            if data["icon-apple"]:
+                text = text.replace("/static/icons/favicon-apple-180x180.png", data["icon-apple"])
             if data["title"]:
                 text = text.replace("<title>Home Assistant</title>", f"<title>{data['title']}</title>")
             return text
@@ -54,6 +54,27 @@ def apply_hooks(hass):
         tpl.render = new_render
         return tpl
 
+    custom_manifest = dict(homeassistant.components.frontend.MANIFEST_JSON)
+
+    if data["title"]:
+        custom_manifest["name"] = data["title"];
+        custom_manifest["short_name"] = data["title"]
+
+    if data["icon-1024"] or data["icon-512"] or data["icon-384"] or data["icon-192"]:
+        custom_icons = []
+
+        if data["icon-1024"]:
+            custom_icons.append({ "sizes": "1024x1024", "src": data["icon-1024"], "type": "image/png" })
+        if data["icon-512"]:
+            custom_icons.append({ "sizes": "512x512", "src": data["icon-512"], "type": "image/png" })
+        if data["icon-384"]:
+             custom_icons.append({ "sizes": "384x384", "src": data["icon-384"], "type": "image/png" })
+        if data["icon-192"]:
+             custom_icons.append({ "sizes": "192x192", "src": data["icon-192"], "type": "image/png" })
+
+        custom_manifest["icons"] = custom_icons
+
+    homeassistant.components.frontend.MANIFEST_JSON = custom_manifest
     homeassistant.components.frontend.IndexView.get_template = _get_template
     return True
 

--- a/custom_components/favicon/config_flow.py
+++ b/custom_components/favicon/config_flow.py
@@ -21,7 +21,12 @@ class ExampleConfigFlow(config_entries.ConfigFlow):
                 {
                     vol.Optional('title'): str,
                     vol.Optional('favicon'): str,
-                    vol.Optional('apple'): str,
+                    vol.Optional('icon-apple'): str,
+                    vol.Optional('icon-1024'): str,
+                    vol.Optional('icon-512'): str,
+                    vol.Optional('icon-384'): str,
+                    vol.Optional('icon-192'): str,
+
                 }
             ),
         )
@@ -47,8 +52,17 @@ class ExampleEditFlow(config_entries.OptionsFlow):
                         default=self.config_entry.options.get("title", "")): str,
                     vol.Optional('favicon',
                         default=self.config_entry.options.get("favicon", "")): str,
-                    vol.Optional('apple',
-                        default=self.config_entry.options.get("apple", "")): str,
+                    vol.Optional('icon-apple',
+                        default=self.config_entry.options.get("icon-apple", "")): str,
+                    vol.Optional('icon-1024',
+                        default=self.config_entry.options.get("icon-1024", "")): str,
+                    vol.Optional('icon-512',
+                        default=self.config_entry.options.get("icon-512", "")): str,
+                    vol.Optional('icon-384',
+                        default=self.config_entry.options.get("icon-384", "")): str,
+                    vol.Optional('icon-192',
+                        default=self.config_entry.options.get("icon-192", "")): str,
+
                 }
             ),
         )


### PR DESCRIPTION
To support also android phones and desktop web apps, the icons in the web manifest gets also modified if configured.

I changed the `apple` config also to `icon-apple` to get some consistency.

This should close #4