### PR TITLE
Fix: Update to use async_update_entry

### DIFF
--- a/custom_components/favicon/__init__.py
+++ b/custom_components/favicon/__init__.py
@@ -41,7 +41,10 @@ async def async_setup(hass, config):
 async def async_setup_entry(hass, config_entry):
     config_entry.add_update_listener(_update_listener)
     if not config_entry.options:
-        config_entry.options = config_entry.data
+        hass.config_entries.async_update_entry(
+            config_entry,
+            options=config_entry.data
+        )
     return await _update_listener(hass, config_entry)
 
 


### PR DESCRIPTION
Home Assistant 2024.9 requires the use of async_update_entry instead of
directly modifying the config_entry object. This change updates the code
to use the new method.

Fixes: #37
Signed-off-by: Andrew Grimberg <tykeal@bardicgrove.org>
