### PR TITLE
Fix compatibility with Home Assistant 2026.x

### DIFF
--- a/custom_components/favicon/__init__.py
+++ b/custom_components/favicon/__init__.py
@@ -41,7 +41,7 @@ async def async_setup(hass, config):
 async def async_setup_entry(hass, config_entry):
     config_entry.add_update_listener(_update_listener)
     if not config_entry.options:
-        config_entry.options = config_entry.data
+        hass.config_entries.async_update_entry(config_entry, options=config_entry.data)
     return await _update_listener(hass, config_entry)
 
 

--- a/custom_components/favicon/config_flow.py
+++ b/custom_components/favicon/config_flow.py
@@ -43,7 +43,7 @@ class EditFlow(config_entries.OptionsFlow):
     async def async_step_init(self, user_input=None):
         if user_input is not None:
             _LOGGER.error(user_input)
-            return self.async_create_entry(title="", data=user_input)
+            return self.async_update_and_abort(self.config_entry, options=user_input)
         return self.async_show_form(
             step_id='init',
             data_schema=vol.Schema(


### PR DESCRIPTION
This PR fixes two bugs that make the integration incompatible with Home Assistant 2026.x, where the config_entries API no longer allows direct assignment to config_entry.options.

Fixes in __init__.py:
- Replaced `config_entry.options = config_entry.data` with `hass.config_entries.async_update_entry(config_entry, options=config_entry.data)`

Fixes in config_flow.py:
- Replaced `return self.async_create_entry(title="", data=user_input)` with `return self.async_update_and_abort(self.config_entry, options=user_input)` in EditFlow.async_step_init

Tested on Home Assistant OS 17.3 with HA Core 2026.6.3.